### PR TITLE
Update gitignore (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-*build
-*out
+/build
+/out
 CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *build
+*out
+CMakeUserPresets.json


### PR DESCRIPTION
I think these are the basic folders/files we can ignore for all projects. Since we don't provide CMakePresets.json, ignore the user presets will allow users to create their own preset file and use it for the project. We could even add a "starter" one in the exemplar.